### PR TITLE
SVG support and some code improvements

### DIFF
--- a/Drawio.php
+++ b/Drawio.php
@@ -117,7 +117,7 @@ function efDrawioParserFunction_Render( &$parser, $name = null, $width = null, $
 			'<input type="hidden" id="drawio-xml" value="'.htmlspecialchars($xml).'">'.  
 			'<input type="hidden" id="drawio-name" value="'.htmlspecialchars($name).'">'.
 			'<input type="hidden" id="drawio-img-type" value="'.htmlspecialchars($img_type).'">'.
-			'<input type="hidden" id="drawio-upload-url" value="http://'.$_SERVER['HTTP_HOST'].$uploadURL.'">'.
+			'<input type="hidden" id="drawio-upload-url" value="'.$uploadURL.'">'.
 			'<input type="hidden" id="drawio-close-url" value="'.$_SERVER['HTTP_REFERER'].'"/>'.		
 		
 			'<div id="resizable" style="width:100%;height:600px">'.

--- a/Drawio.php
+++ b/Drawio.php
@@ -18,6 +18,9 @@ $wgExtensionCredits['parserhook'][] = array(
    'description' => 'Draws pretty diagramms using Draw.io service.'
 );
 
+# Config
+$wgDrawIOImageType = 'png';
+
 # Setup the AnyWikDraw parser function
 function efDrawioParserFunction_Setup() {
     # Setup function hook associating the "drawio" magic word with our function
@@ -44,7 +47,7 @@ function getXml($xmlFileName){
 }
 
 function efDrawioParserFunction_Render( &$parser, $name = null, $width = null, $height = null ) {
-    global $wgUser, $wgLang, $wgTitle, $wgRightsText, $wgOut, $wgArticlePath, $wgScriptPath, $wgEnableUploads;
+    global $wgUser, $wgLang, $wgTitle, $wgRightsText, $wgOut, $wgArticlePath, $wgScriptPath, $wgEnableUploads, $wgDrawIOImageType;
 
     // Don't cache pages with drawio on it
     $parser->disableCache();
@@ -77,7 +80,8 @@ function efDrawioParserFunction_Render( &$parser, $name = null, $width = null, $
     $isProtected = $parser->getTitle()->isProtected();
     
     # Generate the image HTML as if viewed by a web request
-    $image_name = "Drawio_".$name.".png";
+    $img_type = $wgDrawIOImageType;
+    $image_name = "Drawio_".$name.".".$img_type;
     $image = wfFindFile($image_name);
 	
 	$output ='';//.= "xxx " . print_r($image, true) . " xxx";
@@ -112,6 +116,7 @@ function efDrawioParserFunction_Render( &$parser, $name = null, $width = null, $
 		
 			'<input type="hidden" id="drawio-xml" value="'.htmlspecialchars($xml).'">'.  
 			'<input type="hidden" id="drawio-name" value="'.htmlspecialchars($name).'">'.
+			'<input type="hidden" id="drawio-img-type" value="'.htmlspecialchars($img_type).'">'.
 			'<input type="hidden" id="drawio-upload-url" value="http://'.$_SERVER['HTTP_HOST'].$uploadURL.'">'.
 			'<input type="hidden" id="drawio-close-url" value="'.$_SERVER['HTTP_REFERER'].'"/>'.		
 		

--- a/js/drawio.js
+++ b/js/drawio.js
@@ -18,7 +18,7 @@ jQuery(document).ready( function() {
         img_msg = {
             'action':       'export',
             'embedImages':  true,
-            'format':       'png' 
+            'format':       document.getElementById('drawio-img-type').value,
         };
         send_msg(img_msg);
     }
@@ -29,7 +29,7 @@ jQuery(document).ready( function() {
             'xml': xml_data,
 			'drawio': document.getElementById('drawio-name').value,
             'img_type': img_type,
-            'png': img_data
+            'img_data': img_data
         };
 				
 		// special page url


### PR DESCRIPTION
This is a little hack to allow other image types rather than just PNG.

For now, I've just added SVG support, which is probably only really useful if other modules provide native SVG support for mediawiki. A new config option $wgDrawIOImageType controls the image type used by this plugin. It defaults to png, so default behaviour should not be different after applying these changes.

While there, I've slightly improved some of the error handling in Drawio.body.php. I've also changed the upload URI to be relative to make the plugin work for https installations.
